### PR TITLE
改进与建议

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -23,6 +23,7 @@ module.exports = {
   },
   // default font options
   DEFAULT_FONT_OPTIONS: {
+    cssPrefix: 'iconfont',
     fontSize: 32,
     fontFamily: 'iconfont',
   },

--- a/src/css/builder.js
+++ b/src/css/builder.js
@@ -9,7 +9,7 @@ const builder = function(options) {
     return '';
   }
 
-  const fontFaceTemp = fontFace(options.output);
+  const fontFaceTemp = fontFace(options.fontOptions.fontFamily, options.output);
   const iconfontClassTemp = iconfontClass(options.fontOptions);
 
   let iconClassHashTemp = {};
@@ -25,7 +25,7 @@ const builder = function(options) {
     // rename
     const formatName = name.split('/').join('-');
 
-    const iconTemp = icon({
+    const iconTemp = icon(options.fontOptions.cssPrefix, {
       name: formatName,
       unicode: current.unicode,
     });

--- a/src/css/temp/font-face.js
+++ b/src/css/temp/font-face.js
@@ -1,14 +1,16 @@
-module.exports = outputOptions => {
+module.exports = (fontFamily,outputOptions) => {
   const { fileName } = outputOptions;
 
   return {
     '@font-face': {
-      'font-family': 'iconfont',
+      'font-family': fontFamily,
       src: `url(./${fileName}.eot),
           url(./${fileName}.eot?#iefix) format('embedded-opentype'),
           url(./${fileName}.woff) format('woff'),
           url(./${fileName}.ttf) format('truetype'),
           url(./${fileName}.svg#iconfont) format('svg')`,
+      'font-weight': 'normal',
+      'font-style': 'normal'
     },
   };
 };

--- a/src/css/temp/icon.js
+++ b/src/css/temp/icon.js
@@ -1,8 +1,8 @@
-module.exports = icon => {
+module.exports = (cssPrefix, icon) => {
   const { name, unicode } = icon;
 
   return {
-    [`.iconfont-${name}::before`]: {
+    [`.${cssPrefix}-${name}::before`]: {
       content: `"\\${unicode}"`,
     },
   };

--- a/src/css/temp/iconfont-class.js
+++ b/src/css/temp/iconfont-class.js
@@ -1,9 +1,13 @@
 module.exports = fontOptions => {
-  const { fontFamily, fontSize } = fontOptions;
-
-  return {
-    '.icon-iconfont': {
-      font: `normal normal normal ${fontSize}px/1 "${fontFamily}";`,
-    },
-  };
+  const { cssPrefix, fontFamily } = fontOptions;
+  let obj = {}
+  obj[`[class^=\"${cssPrefix}\"], [class*=\" ${cssPrefix}\"]`]=
+    {
+      'font-family': `'${fontFamily}' !important;`,
+      '-webkit-font-smoothing': 'antialiased;',
+      '-moz-osx-font-smoothing': 'grayscale;',
+      'font-style': 'normal;'
+      // font: `normal normal normal ${fontSize}px/1 "${fontFamily}";`,
+    };
+  return obj;
 };


### PR DESCRIPTION
增加了前缀适配，不必使用.icon-iconfont来激活字体配置
取消了默认字体大小，因为大部分使用样式地方有自身的字体设置
修复了font-family设置无效的问题

建议：
增加生成文件名的hash参数
变更assetsPath参数名称，容易和webpack参数混淆
生成文件的根路径参照webpack的assetsPath参数
可以增加formats数组参数，控制 eot ttf woff woff2
增加生成模板配置